### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/apisak-w/pwa-expense-manager/security/code-scanning/1](https://github.com/apisak-w/pwa-expense-manager/security/code-scanning/1)

To fix the problem, we need to add a `permissions` block to the workflow, using the least privilege principle. Since the workflow only runs tests, linter, and build steps, and does not appear to need write access to any repository contents or GitHub resources, we should set permissions to allow read-only access to code contents. The recommended minimal starting point is `permissions: contents: read`. This can be set at the workflow level (top of the YAML, just after the `name:` and before `on:`), so that all jobs inherit these restricted permissions. No additional methods or definitions are required, only an edit to the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
